### PR TITLE
Added configurable threshold/timeout for individual lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+# ignore the binary produced by `go build`
+dns-slap

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A per-lookup threshold (in milliseconds) can also be configured. If a single loo
 Usage of dns-slap
   -concurrency=10: How many concurrent lookups to try
   -iterations=100: How many times to lookup in each concurrent process
-  -threshold=100:  How long to wait (in milliseconds) on a single lookup before considering it a failure
+  -threshold=500:  How long to wait (in milliseconds) on a single lookup before considering it a failure
 ```
 
 This is what happens when you run dns-slap

--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ Simple as it takes to type the following command:
 
 dns-slap supports setting a concurrency level and the number of iterations to lookup a DNS entry per concurrent processes.
 
+A per-lookup threshold (in milliseconds) can also be configured. If a single lookup takes longer than the configurable threshold (even if successful) it will be considered a failure for reporting purposes.
+
 ```bash
 Usage of dns-slap
   -concurrency=10: How many concurrent lookups to try
   -iterations=100: How many times to lookup in each concurrent process
+  -threshold=100:  How long to wait (in milliseconds) on a single lookup before considering it a failure
 ```
 
 This is what happens when you run dns-slap


### PR DESCRIPTION
This pull request adds a configurable threshold (specified on the CLI in milliseconds) for individual lookups. If an individual lookup takes longer than the specified threshold, it will be reported as an error (even if it finishes successfully).